### PR TITLE
Add X-Requested-With header for CSRF defenses

### DIFF
--- a/src/PIWebApiWrapper/PIWebApiWrapper/Client/ApiClient.cs
+++ b/src/PIWebApiWrapper/PIWebApiWrapper/Client/ApiClient.cs
@@ -127,6 +127,10 @@ namespace PIWebAPIWrapper.Client
             foreach (var param in headerParams)
                 request.AddHeader(param.Key, param.Value);
 
+            // add X-Requested-With header to work with CSRF defences
+            // https://techsupport.osisoft.com/Troubleshooting/KB/KB01650/
+            request.AddHeader("X-Requested-With", "PIWebApiWrapper");
+
             // add query parameter, if any
             foreach (var param in queryParams)
                 request.AddQueryParameter(param.Key, param.Value);


### PR DESCRIPTION
Add the X-Request-With header to all requests so that POST calls are not
blocked by the PI Web API when CSRF defenses are enabled.

Fixes #1.

Note that I did not recompile the PIWebApiWrapper.dll with the change. Let me know if you'd like me to do that, I can push another commit to this branch.